### PR TITLE
Archiving a Codable struct

### DIFF
--- a/Sources/codable/main.swift
+++ b/Sources/codable/main.swift
@@ -1,8 +1,20 @@
 import Foundation
 
 struct Foo : Codable {
-  let bar: String = "test"
+    let bar: String = "test"
 }
 
 let foo = Foo()
-NSKeyedArchiver.archiveRootObject(foo, toFile: "/tmp/foo.dat")
+
+// encode and archive
+let key = "foo-key"
+let archiver = NSKeyedArchiver()
+try archiver.encodeEncodable(foo, forKey: key)
+
+let path = URL(fileURLWithPath: "/tmp/foo.dat")
+try archiver.encodedData.write(to: path)
+
+// read and decode
+let archivedData = try Data(contentsOf: path)
+let unarchiver = NSKeyedUnarchiver(forReadingWith: archivedData)
+let decodedFoo = unarchiver.decodeDecodable(Foo.self, forKey: key)


### PR DESCRIPTION
Using `encodeEncodable(_: forKey:)` from `NSKeyedArchived` and `decodeDecodable(_, forKey:)` from `NSKeyedUnarchiver` to archive a Codable struct in Swift 4.